### PR TITLE
Fix Recording logic and aspect ratio in the backend

### DIFF
--- a/backend/streamer/session.js
+++ b/backend/streamer/session.js
@@ -68,20 +68,16 @@ export class Session {
       if (this.videoPath && this.videoPath !== -1) {
         const highlighter = new Highlighter(this.videoPath)
         try {
-          const { finalVideo, thumbnail, croppedVideo, croppedThumbnail } =
-            await highlighter.highlight()
-          logger('Local paths:', {
-            finalVideo,
-            thumbnail,
-            croppedVideo,
-            croppedThumbnail,
-          })
+          const { reelVideo, thumbnail } = await highlighter.highlight(
+            durationInSeconds
+          )
+          logger('Local paths:', { reelVideo, thumbnail })
 
           logger('Uploading...')
-          const onlineReelLink = await uploadVideo(croppedVideo)
+          const onlineReelLink = await uploadVideo(reelVideo)
           logger('## ~ onlineReelLink:', onlineReelLink)
 
-          const onlineThumbnailLink = await uploadImage(croppedThumbnail)
+          const onlineThumbnailLink = await uploadImage(thumbnail)
           logger('## ~ onlineThumbnailLink:', onlineThumbnailLink)
 
           // Return the online links


### PR DESCRIPTION
This PR polishes the back-end and makes it work automatically parallel to TouchDesigner.

- recording the stream out from TouchDesigner
- cut short version of the recorded video (30seconds)
- generate thumbnail of the short Reel video
- upload both Thumbnail and short Reel video automatically to the website